### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: Run Tests
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+
+jobs:
+  build_test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        perl:
+          - '5.38'
+          - '5.36'
+          - '5.34'
+          - '5.32'
+          - '5.30'
+          - '5.28'
+          - '5.26'
+          - '5.24'
+          - '5.22'
+    name: Perl ${{ matrix.perl }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up perl
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: ${{ matrix.perl }}
+
+      - run: perl -V
+
+      - name: Install Perl deps
+        run: |
+          cpanm --notest --installdeps --with-develop .
+
+      - name: Run tests
+        id: run-tests
+        if: ${{ success() }}
+        run: |
+          prove -lr --jobs $(nproc --all) --state save
+
+      - name: Archive .prove (for 30 days)
+        uses: actions/upload-artifact@master
+        if: ${{ failure() && steps.run-tests.conclusion == 'failure' }}
+        with:
+          name: .prove-${{ matrix.perl }}
+          path: .prove

--- a/lib/Data/Checks.pm
+++ b/lib/Data/Checks.pm
@@ -18,7 +18,7 @@ sub import {
     strict->import::into($caller);
     warnings->import::into($caller);
     feature->import::into( $caller, ':5.22' );
-    experimental->import::into( $caller, 'signatures' );
+    experimental->import::into( $caller, 'signatures', 'lexical_subs' );
     Data::Checks::Parser->import::into( $caller, @args );
 }
 
@@ -86,7 +86,7 @@ The statement C<use Data::Checks> is equivalent to:
     use strict;
     use warnings;
     use v5.22;
-    use experimental 'signatures';
+    use experimental 'signatures', 'lexical_subs';
     use Data::Checks::Parser;    # this is the magic
 
 =head1 CORE CHECKS

--- a/t/bug-state-error.t
+++ b/t/bug-state-error.t
@@ -2,6 +2,7 @@
 
 use Test::Most;
 use Data::Checks;
+use experimental qw(postderef);
 
 explain <<'END';
 There was a bug where feature 'state' wasn't always imported. Further, there

--- a/t/subroutines.t
+++ b/t/subroutines.t
@@ -14,7 +14,7 @@ FAIL_ON_PARAM { foo(-42) } 'foo(-42)';
 eval { foo(3) };
 my $err = $@ // '';
 like( $err, qr/\QCan't assign -2.43 to \E\$max_size: failed UINT check/, 'foo(3)' );
-like( $err, qr{\Qat t/subroutines.t line 8\E}, '...at correct location' );
+like( $err, qr{at .*\Qsubroutines.t line 8\E}, '...at correct location' );
 }
 
 OKAY { no checks; foo(-42) } 'no checks; foo(-42)';


### PR DESCRIPTION
This is an initial workflow (Linux only). There seem to still be a bug that `t/bug-state-error.t` is supposed to capture, but only on Perl 5.22 and 5.24.