### PR TITLE
Split check into outer and inner for scalar parameters

### DIFF
--- a/lib/Data/Checks/Parser.pm
+++ b/lib/Data/Checks/Parser.pm
@@ -1376,6 +1376,7 @@ sub _rewrite_sub ($decl_ref) {
 
     # Extract parameter :of specifiers (if any)...
     my $OF_CHECKS = q{};
+    my $OF_CHECKS_INNER = q{};
     if ( $decl_ref->{syn_sig} ) {
         while ( $decl_ref->{syn_sig} =~ s{ $EXTRACT_OF }{$+{param}}xms ) {
 
@@ -1393,7 +1394,9 @@ sub _rewrite_sub ($decl_ref) {
 
                 # Install extra code at start of sub to check parameter...
                 $OF_CHECKS
-                  .= qq{Data::Checks::Parser::FAIL q{Can't pass } . Data::Checks::Parser::pp($of{param}) . q{ to parameter $of{param} in call to $decl_ref->{syn_name}\() at } . join(' line ', (caller)[1,2]) . qq{:\\nValue failed parameter's \Q$of{check}\E check.\\n} if !$pass_check; Variable::Magic::cast $of{param}, \$Data::Checks::Parser::SCALAR_WIZARD_FOR{q{$of{param}/$of{check}}}; };
+                  .= qq{Data::Checks::Parser::FAIL q{Can't pass } . Data::Checks::Parser::pp($of{param}) . q{ to parameter $of{param} in call to $decl_ref->{syn_name}\() at } . join(' line ', (caller)[1,2]) . qq{:\\nValue failed parameter's \Q$of{check}\E check.\\n} if !$pass_check; };
+                $OF_CHECKS_INNER
+                  .= qq{Variable::Magic::cast $of{param}, \$Data::Checks::Parser::SCALAR_WIZARD_FOR{q{$of{param}/$of{check}}}; };
             }
             elsif ( $of{sigil} eq '@' ) {
 
@@ -1458,6 +1461,7 @@ sub _rewrite_sub ($decl_ref) {
                 state sub __IMPL__ «sig» {
                     local *__ANON__ = __PACKAGE__ . q{::«name»};
                     no warnings 'once', 'redefine';
+                    if ((((caller 1)[10] // {})->{'Data::Checks::Parser/mode'}//q{}) ne 'NONE') {$OF_CHECKS_INNER}
                     local *CORE::GLOBAL::caller = \\&Data::Checks::Parser::_caller;
                     «block»
                 }

--- a/t/subroutines.t
+++ b/t/subroutines.t
@@ -1,0 +1,24 @@
+use Test::More;
+
+use Data::Checks;
+use lib qw< tlib t/tlib >;
+use Data::Checks::TestUtils 'UINT';
+
+sub foo ( $max_size :of(UINT) ) {
+    $max_size = -2.43;
+}
+
+FAIL_ON_PARAM { foo(-42) } 'foo(-42)';
+
+{
+eval { foo(3) };
+my $err = $@ // '';
+like( $err, qr/\QCan't assign -2.43 to \E\$max_size: failed UINT check/, 'foo(3)' );
+like( $err, qr{\Qat t/subroutines.t line 8\E}, '...at correct location' );
+}
+
+OKAY { no checks; foo(-42) } 'no checks; foo(-42)';
+
+OKAY { no checks; foo(3) } 'no checks; foo(3)';
+
+done_testing();


### PR DESCRIPTION
This adds the magic to the variable in the correct scope.

Fixes <https://github.com/Perl-Oshun/oshun/issues/1>.
