### PR TITLE
Ovid/fix sub args

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-
+use 5.220;
 
 use ExtUtils::MakeMaker;
 
@@ -13,6 +13,7 @@ my %WriteMakefileArgs = (
   },
   "DISTNAME" => "Data-Checks",
   "LICENSE" => "artistic_2",
+  "MIN_PERL_VERSION" => "5.220",
   "NAME" => "Data::Checks",
   "PREREQ_PM" => {
     "Data::Dump" => "0.25",

--- a/cpanfile
+++ b/cpanfile
@@ -10,6 +10,7 @@ requires "Sub::Uplevel" => "0.2800";
 requires "Variable::Magic" => "0.63";
 requires "attributes" => "0";
 requires "experimental" => "0";
+requires "perl" => "5.22";
 
 on 'test' => sub {
   requires "ExtUtils::MakeMaker" => "0";

--- a/cpanfile
+++ b/cpanfile
@@ -31,6 +31,7 @@ on 'configure' => sub {
 
 on 'develop' => sub {
   requires "File::Spec" => "0";
+  requires "Hash::Ordered" => "0.014";
   requires "IO::Handle" => "0";
   requires "IPC::Open3" => "0";
   requires "Test::More" => "0";

--- a/dist.ini
+++ b/dist.ini
@@ -50,6 +50,7 @@ Variable::Magic = 0.63
 -phase = develop
 -relationship = requires
 Test::Most      = 0.38
+Hash::Ordered   = 0.014
 
 [CPANFile]
 

--- a/dist.ini
+++ b/dist.ini
@@ -39,6 +39,7 @@ skip = TestUtils
 ; Windows test failures were caused by having version of Type::Tiny and
 ; friends which were released in 2014!
 [Prereqs]
+perl            = 5.22
 PPR             = 0.001008
 Import::Into    = 1.002005
 Sub::Uplevel    = 0.2800

--- a/lib/Data/Checks/Parser.pm
+++ b/lib/Data/Checks/Parser.pm
@@ -1457,6 +1457,7 @@ sub _rewrite_sub ($decl_ref) {
             «ws_preblock»      {
                 state sub __IMPL__ «sig» {
                     local *__ANON__ = __PACKAGE__ . q{::«name»};
+                    if ((((caller 4)[10] // {})->{'Data::Checks::Parser/mode'}//q{}) ne 'NONE') {$OF_CHECKS}
                     no warnings 'once', 'redefine';
                     local *CORE::GLOBAL::caller = \\&Data::Checks::Parser::_caller;
                     «block»

--- a/t/regressions.t
+++ b/t/regressions.t
@@ -1,0 +1,23 @@
+use v5.22;
+
+use Test::Most;
+use Data::Checks;
+use warnings;
+no warnings 'experimental::signatures';
+
+# There was a bug in subroutines where checks would be checked on subroutine
+# entry, but not in the body. This test ensures that the checks are enforced
+# in the body and subsequent changes don't skip that.
+# https://github.com/Perl-Oshun/oshun/issues/1
+
+sub bad_assigment_in_body ( $max_size : of(UINT) ) {
+    my $new_value = $max_size;
+    $max_size = -2.43 if $max_size == 3;
+    return 1 + $new_value;
+}
+
+throws_ok { bad_assigment_in_body(3) } qr/Can't assign -2.43 to \$max_size: failed UINT check/,
+  'Checks declared on arguments are enforced';
+is bad_assigment_in_body(4), 5, '... but if we skip our bad assignment, we get the right answer';
+
+done_testing,


### PR DESCRIPTION
This is ticket #1 

Previously, when a check was applied on a subroutine argument, it was only applied at subroutine entry, not in the body. Thus, this worked:

```perl
sub this ($nth :of(UINT)) {
    $nth = 'this is not a uint';
}
```

Checks are now enforced inside the subroutine body. Thanks to @zmughal for spotting the error!

Also, `dist.ini` now requires v5.22.0 as the minimum version of Perl and sets `Hash::Ordered` as a dependency for the tests.