### PR TITLE
Ovid/min versions

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-
+use 5.022000;
 
 use ExtUtils::MakeMaker;
 
@@ -13,6 +13,7 @@ my %WriteMakefileArgs = (
   },
   "DISTNAME" => "Data-Checks",
   "LICENSE" => "artistic_2",
+  "MIN_PERL_VERSION" => "5.022000",
   "NAME" => "Data::Checks",
   "PREREQ_PM" => {
     "Data::Dump" => "0.25",

--- a/cpanfile
+++ b/cpanfile
@@ -10,6 +10,7 @@ requires "Sub::Uplevel" => "0.2800";
 requires "Variable::Magic" => "0.63";
 requires "attributes" => "0";
 requires "experimental" => "0";
+requires "perl" => "v5.22.0";
 
 on 'test' => sub {
   requires "ExtUtils::MakeMaker" => "0";

--- a/cpanfile
+++ b/cpanfile
@@ -31,6 +31,7 @@ on 'configure' => sub {
 
 on 'develop' => sub {
   requires "File::Spec" => "0";
+  requires "Hash::Ordered" => "0.014";
   requires "IO::Handle" => "0";
   requires "IPC::Open3" => "0";
   requires "Test::More" => "0";

--- a/dist.ini
+++ b/dist.ini
@@ -50,6 +50,7 @@ Variable::Magic = 0.63
 -phase = develop
 -relationship = requires
 Test::Most      = 0.38
+Hash::Ordered   = 0.014
 
 [CPANFile]
 

--- a/dist.ini
+++ b/dist.ini
@@ -39,6 +39,7 @@ skip = TestUtils
 ; Windows test failures were caused by having version of Type::Tiny and
 ; friends which were released in 2014!
 [Prereqs]
+perl            = v5.22.0
 PPR             = 0.001008
 Import::Into    = 1.002005
 Sub::Uplevel    = 0.2800


### PR DESCRIPTION
No ticket.

* Minimum Perl version now set to 5.22.
* `Hash::Ordered` added to test dependencies