### PR TITLE
Trivial README.md update to correct valid Celsius range

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ However, that doesn't really make sense, since that's below absolute zero.
 So we have user-defined checks:
 
 ```perl
-check Celsius    :isa(NUM[-273.14..inf]);
+check Celsius    :isa(NUM[-273.15..inf]);
 check Fahrenheit :isa(NUM[−459.67..inf]);
 ```
 


### PR DESCRIPTION
Super-trivial correction to the README.md Celsius example. Absolute zero is -273.15 °C.

https://en.wikipedia.org/wiki/Absolute_zero